### PR TITLE
feat: Add Playwright tests for authentication

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,40 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo
+        ports:
+          - 27017:27017
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install root dependencies
+      run: npm install
+    - name: Install frontend dependencies
+      run: npm install --prefix frontend
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps --prefix frontend
+    - name: Create .env file
+      run: echo "MONGO_DB_URI=mongodb://mongodb:27017/test" > .env
+    - name: Start backend server
+      run: npm start &
+    - name: Wait for backend server
+      run: npx wait-on http://localhost:5000
+    - name: Run Playwright tests
+      run: npx playwright test --prefix frontend
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: frontend/playwright-report/
+        retention-days: 30

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,7 @@
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@playwright/test": "^1.55.0",
+        "@types/node": "^24.3.1",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1114,6 +1116,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
@@ -1450,6 +1468,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
@@ -4497,6 +4525,53 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -5808,6 +5883,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@playwright/test": "^1.55.0",
+    "@types/node": "^24.3.1",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/frontend/tests/auth.spec.js
+++ b/frontend/tests/auth.spec.js
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Authentication', () => {
+  test('should allow a user to sign up', async ({ page }) => {
+    const username = `testuser_${Math.random().toString(36).substring(2, 10)}`;
+    const password = 'password123';
+
+    await page.goto('/signup');
+
+    await page.fill('input[placeholder="John Doe"]', 'Test User');
+    await page.fill('input[placeholder="johndoe"]', username);
+    await page.fill('input[placeholder="Enter Password"]', password);
+    await page.fill('input[placeholder="Confirm Password"]', password);
+    await page.check('input[type="checkbox"] >> nth=0'); // Select the first gender checkbox
+
+    await page.click('button:has-text("Sign Up")');
+
+    // After signup, the user should be logged in and on the home page.
+    // A good indicator of being on the home page is the presence of the logout button.
+    await expect(page.locator('button:has-text("Logout")')).toBeVisible();
+  });
+
+  test('should allow a user to login', async ({ page }) => {
+    const username = `testuser_${Math.random().toString(36).substring(2, 10)}`;
+    const password = 'password123';
+    const fullName = 'Test User';
+    const gender = 'male';
+
+    // Create a new user via API
+    const response = await page.request.post('/api/auth/signup', {
+      data: {
+        fullName,
+        username,
+        password,
+        confirmPassword: password,
+        gender,
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    await page.goto('/login');
+
+    await page.fill('input[placeholder="Enter username"]', username);
+    await page.fill('input[placeholder="Enter Password"]', password);
+
+    await page.click('button:has-text("Login")');
+
+    // After login, the user should be on the home page.
+    await expect(page.locator('button:has-text("Logout")')).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "server": "nodemon backend/server.js",
-    "start": "node backend/server.js",
+    "start": "node -r dotenv/config backend/server.js",
     "build": "npm install && npm install --prefix frontend && npm run build --prefix frontend"
   },
   "type": "module",
@@ -23,6 +23,7 @@
     "socket.io": "^4.8.1"
   },
   "devDependencies": {
-    "nodemon": "^3.1.9"
+    "nodemon": "^3.1.9",
+    "wait-on": "^7.2.0"
   }
 }


### PR DESCRIPTION
This commit introduces Playwright tests for the user authentication flow. It includes tests for user signup and login.

The following changes were made:
- Installed Playwright and configured it for the project.
- Created a new test file `frontend/tests/auth.spec.js` with independent tests for signup and login.
- Added a `.env` file with a dummy MongoDB URI to allow the backend to start for the tests.
- Updated `package.json` to load the `.env` file and added `wait-on` for the CI workflow.
- Created a GitHub Actions workflow to automate the testing process, including a MongoDB service.